### PR TITLE
tmpl: fix package name resolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,11 @@ protoc --doc_out="template=templates/tmpl.html:doc/" file.proto
 ```
 
 Would produce documentation using `templates/tmpl.html` inside the `doc/` output directory for `file.proto`.
+
+# proto_path issues
+
+You will quickly find that the generator fails if you run it with a `--proto_path` argument. This is because `protoc` does not pass it's command-line arguments onto generator programs (and `protoc-gen-doc` needs to know the `--proto_path` arguments in order to resolve symbols appropriately). To workaround this issue you must export the `$PROTO_PATH` environment variable, thus you can run `protoc` as just:
+
+```
+PROTO_PATH="--proto_path=/my/custom/path" protoc $(PROTO_ARGS) --doc_out="template=templates/tmpl.html:doc/" file.proto
+```

--- a/tmpl/generator.go
+++ b/tmpl/generator.go
@@ -54,14 +54,9 @@ func (g *Generator) Generate() (response *plugin.CodeGeneratorResponse, err erro
 	errs := new(bytes.Buffer)
 	buf := new(bytes.Buffer)
 	for _, f := range g.Request.GetProtoFile() {
-		ctx := &tmplFuncs{
-			f:   f,
-			ext: ext,
-		}
-
 		// Execute the template and generate a response for the input file.
 		buf.Reset()
-		err := g.Template.Funcs(ctx.funcMap()).Execute(buf, f)
+		err := g.Template.Funcs(newTmplFuncs(f, ext).funcMap()).Execute(buf, f)
 
 		// If an error occured during executing the template, we pass it pack to
 		// protoc via the error field in the response.

--- a/tmpl/util_test.go
+++ b/tmpl/util_test.go
@@ -1,6 +1,9 @@
 package tmpl
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestUnixPath(t *testing.T) {
 	var paths = map[string]string{
@@ -26,6 +29,30 @@ func TestStripExt(t *testing.T) {
 		got := stripExt(f)
 		if got != correct {
 			t.Fatalf("got %q expected %q", got, correct)
+		}
+	}
+}
+
+func TestPkgStmt(t *testing.T) {
+	var tests = [][2]string{
+		{"package foobar3;\n", "foobar3"},
+		{"package foobar3   \t; \n", "foobar3"},
+		{"package FooBar3;\n", "FooBar3"},
+		{"package foo-bar3;\n", ""},
+		{"package foo3; // comments are silly", "foo3"},
+		{" \t package foobar3;\n", "foobar3"},
+		{"BAH\n \t package foo4;\n", "foo4"},
+		{"// package notIt;\n  package 3eggs3;\n", "3eggs3"},
+	}
+	for _, tst := range tests {
+		pkg, err := pkgStmt(bytes.NewReader([]byte(tst[0])))
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantPkg := tst[1]
+		if pkg != wantPkg {
+			t.Logf("%q\n", tst[0])
+			t.Fatalf("got=%q want=%q\n", pkg, wantPkg)
 		}
 	}
 }


### PR DESCRIPTION
This change fixes package name resolving by parsing the proto files with
a small regexp for their package name, and falling back to the filename (per
proto spec) if no package statement is available.

The approach was based around the idea of streaming rather than buffering
the entire file in memory, but because `*bufio.Reader` does not implement the
`io.Seeker` interface this effectively does not work. It's still better than
before (you can now click on types in docs whose filename is not the package name), but eventually this issue should be resolved for better performance / code clarity.

EDIT: see [my comment below](https://github.com/sourcegraph/prototools/pull/2#discussion_r29987766) about how I have a more correct fix for this in mind, though this does fix the issue for now.