### PR TITLE
tmpl: fix package name resolving

### DIFF
--- a/tmpl/generator.go
+++ b/tmpl/generator.go
@@ -38,7 +38,7 @@ type Generator struct {
 // If any error is encountered during generation, it is returned and should be
 // considered fatal to the generation process (the response will be nil).
 func (g *Generator) Generate() (response *plugin.CodeGeneratorResponse, err error) {
-	// Reset the response to it's initial state.
+	// Reset the response to its initial state.
 	g.response.Reset()
 
 	// Parse command-line parameters.

--- a/tmpl/generator.go
+++ b/tmpl/generator.go
@@ -53,10 +53,12 @@ func (g *Generator) Generate() (response *plugin.CodeGeneratorResponse, err erro
 	// Generate each proto file:
 	errs := new(bytes.Buffer)
 	buf := new(bytes.Buffer)
-	for _, f := range g.Request.GetProtoFile() {
+	protoFile := g.Request.GetProtoFile()
+	for _, f := range protoFile {
 		ctx := &tmplFuncs{
-			f:   f,
-			ext: ext,
+			f:         f,
+			ext:       ext,
+			protoFile: protoFile,
 		}
 
 		// Execute the template and generate a response for the input file.

--- a/tmpl/util.go
+++ b/tmpl/util.go
@@ -187,7 +187,7 @@ func (f *tmplFuncs) fullyQualified(typePath string) string {
 	return fmt.Sprintf(".%s.%s", pkg, typePath)
 }
 
-// resolvePkgPath resolves the named protobuf package, returning it's file
+// resolvePkgPath resolves the named protobuf package, returning its file
 // path.
 func (f *tmplFuncs) resolvePkgPath(pkg string) string {
 	for _, file := range f.protoFile {

--- a/tmpl/util.go
+++ b/tmpl/util.go
@@ -61,8 +61,9 @@ type cacheItem struct {
 // the FuncMap above for these to be called properly (as they are actually
 // closures with context).
 type tmplFuncs struct {
-	f   *descriptor.FileDescriptorProto
-	ext string
+	f         *descriptor.FileDescriptorProto
+	ext       string
+	protoFile []*descriptor.FileDescriptorProto
 
 	locCache []cacheItem
 }
@@ -188,22 +189,12 @@ func (f *tmplFuncs) fullyQualified(typePath string) string {
 
 // resolvePkgPath resolves the named protobuf package, returning it's file
 // path.
-//
-// TODO(slimsag): This function assumes that the package ("package foo;") is
-// named identically to its file name ("foo.proto"). Protoc doesn't pass such
-// information to us because it hasn't parsed all the files yet -- we will most
-// likely have to scan for the package statement in these dependency files
-// ourselves.
 func (f *tmplFuncs) resolvePkgPath(pkg string) string {
-	// Test this proto file itself:
-	if stripExt(filepath.Base(*f.f.Name)) == pkg {
-		return *f.f.Name
-	}
-
-	// Test each dependency:
-	for _, p := range f.f.Dependency {
-		if stripExt(filepath.Base(p)) == pkg {
-			return p
+	for _, file := range f.protoFile {
+		for _, d := range strings.Split(file.GetPackage(), ".") {
+			if d == pkg {
+				return file.GetName()
+			}
 		}
 	}
 	return ""

--- a/tmpl/util.go
+++ b/tmpl/util.go
@@ -191,6 +191,13 @@ func (f *tmplFuncs) fullyQualified(typePath string) string {
 // path.
 func (f *tmplFuncs) resolvePkgPath(pkg string) string {
 	for _, file := range f.protoFile {
+		// A file's package name is for example:
+		//
+		//  package pbtypes; // GetPackage() == "pbtypes"
+		//  package google.protobuf; // GetPackage() == "google.protobuf"
+		//
+		// For the latter case we need to resolve a package like "google" to the
+		// package named "google.protobuf".
 		for _, d := range strings.Split(file.GetPackage(), ".") {
 			if d == pkg {
 				return file.GetName()


### PR DESCRIPTION
This change fixes package name resolving correctly, by checking against the
CodeGeneratorRequest.ProtoFile list. The list contains all the files that protoc
wants us to generate plus all the files they import, in a topological order (which
is perfect for name resolution).

Replaces the hack-y PR #2