### PR TITLE
Fix links to symbols in documentation

### DIFF
--- a/templates/tmpl.html
+++ b/templates/tmpl.html
@@ -71,7 +71,7 @@
 			<h1>Enums</h1>
 			{{range $e := .EnumType}}
 				<div class="doc-inner">
-					<h2 id="{{fullyQualified $e.Name}}">Enum: {{$e.Name}}</h2>
+					<h2 id="{{$e.Name}}">Enum: {{$e.Name}}</h2>
 					{{template "CommentsParagraph" $e}}
 					{{if .Value}}
 						<table>
@@ -96,7 +96,7 @@
 			<h1>Extensions</h1>
 			{{range $e := .Extension}}
 				<div class="doc-inner">
-					<h2 id="{{fullyQualified $e.Name}}">Extension: {{$e.Name}}</h2>
+					<h2 id="{{$e.Name}}">Extension: {{$e.Name}}</h2>
 					{{template "CommentsParagraph" $e}}
 				</div>
 			{{end}}
@@ -109,7 +109,7 @@
 			<h1>Services</h1>
 			{{range $s := .Service}}
 				<div class="doc-inner">
-					<h2 id="{{fullyQualified $s.Name}}">Service: {{$s.Name}}</h2>
+					<h2 id="{{$s.Name}}">Service: {{$s.Name}}</h2>
 					{{template "CommentsParagraph" $s}}
 					<table>
 						<tr><td>Method</td><td>Input Type</td><td>Output Type</td><td>Description</td></tr>
@@ -137,7 +137,7 @@
 			<h1>Messages</h1>
 			{{range $m := .MessageType}}
 				<div class="doc-inner">
-					<h2 id="{{fullyQualified $m.Name}}">Message: {{$m.Name}}</h2>
+					<h2 id="{{$m.Name}}">Message: {{$m.Name}}</h2>
 					{{template "CommentsParagraph" $m}}
 					<table>
 						<tr><td>#</td><td>Field</td><td>Label</td><td>Type</td><td>Description</td></tr>

--- a/tmpl/generator.go
+++ b/tmpl/generator.go
@@ -45,10 +45,12 @@ func (g *Generator) Generate() (response *plugin.CodeGeneratorResponse, err erro
 	// Generate each proto file:
 	errs := new(bytes.Buffer)
 	buf := new(bytes.Buffer)
-	for _, f := range g.Request.GetProtoFile() {
+	protoFile := g.Request.GetProtoFile()
+	for _, f := range protoFile {
 		ctx := &tmplFuncs{
-			f:   f,
-			ext: ext,
+			f:         f,
+			ext:       ext,
+			protoFile: protoFile,
 		}
 
 		// Execute the template and generate a response for the input file.

--- a/tmpl/generator.go
+++ b/tmpl/generator.go
@@ -33,7 +33,7 @@ type Generator struct {
 // If any error is encountered during generation, it is returned and should be
 // considered fatal to the generation process (the response will be nil).
 func (g *Generator) Generate() (response *plugin.CodeGeneratorResponse, err error) {
-	// Reset the response to it's initial state.
+	// Reset the response to its initial state.
 	g.response.Reset()
 
 	// Determine the extension string.

--- a/tmpl/util.go
+++ b/tmpl/util.go
@@ -145,8 +145,7 @@ func (f *tmplFuncs) urlToType(symbolPath string) string {
 	return fmt.Sprintf("%s#%s", rel, typePath)
 }
 
-// resolvePkgPath resolves the named protobuf package, returning it's file
-// path.
+// resolvePkgPath resolves the named protobuf package, returning its file path.
 //
 // TODO(slimsag): This function assumes that the package ("package foo;") is
 // named identically to its file name ("foo.proto"). Protoc doesn't pass such

--- a/tmpl/util.go
+++ b/tmpl/util.go
@@ -72,12 +72,11 @@ type tmplFuncs struct {
 // funcMap returns the function map for feeding into templates.
 func (f *tmplFuncs) funcMap() template.FuncMap {
 	return map[string]interface{}{
-		"cleanLabel":     f.cleanLabel,
-		"cleanType":      f.cleanType,
-		"fieldType":      f.fieldType,
-		"urlToType":      f.urlToType,
-		"fullyQualified": f.fullyQualified,
-		"location":       f.location,
+		"cleanLabel": f.cleanLabel,
+		"cleanType":  f.cleanType,
+		"fieldType":  f.fieldType,
+		"urlToType":  f.urlToType,
+		"location":   f.location,
 	}
 }
 
@@ -130,16 +129,13 @@ func (f *tmplFuncs) urlToType(symbolPath string) string {
 	}
 	pkgPath := file.GetName()
 
-	// TODO(slimsag): Remove the package prefix from types, for example:
+	// Remove the package prefix from types, for example:
 	//
 	//  pkg.html#.pkg.Type.SubType
 	//  ->
 	//  pkg.html#Type.SubType
 	//
-	// This requires changes to how the IDs for those are generated in
-	// the HTML elsewhere.
-	//typePath := util.TrimElem(symbolPath, util.CountElem(file.GetPackage()))
-	typePath := symbolPath
+	typePath := util.TrimElem(symbolPath, util.CountElem(file.GetPackage()))
 
 	// Make the path relative to this documentation files directory and then swap
 	// the extension out.
@@ -147,22 +143,6 @@ func (f *tmplFuncs) urlToType(symbolPath string) string {
 	rel, _ := filepath.Rel(basePath, pkgPath)
 	rel = stripExt(rel) + f.ext
 	return fmt.Sprintf("%s#%s", rel, typePath)
-}
-
-// fullyQualified returns the fully qualified path for the given type path.
-//
-// TODO(slimsag): this is incomplete as it assumes the scope is only relative
-// to the package, i.e. for ".foo.bar.baz" fullyQualified("baz") would return
-// ".foo.baz" incorrectly. Handling such cases requires more extensive C++
-// style scope crawling.
-func (f *tmplFuncs) fullyQualified(typePath string) string {
-	if typePath[0] == '.' {
-		return typePath
-	}
-
-	// Not fully-qualified.
-	pkg := stripExt(filepath.Base(*f.f.Name))
-	return fmt.Sprintf(".%s.%s", pkg, typePath)
 }
 
 // resolvePkgPath resolves the named protobuf package, returning it's file

--- a/util/gen.go
+++ b/util/gen.go
@@ -1,0 +1,3 @@
+package util
+
+//go:generate protoc --proto_path=testdata/resolve --json_out=out=resolver.json:testdata/ testdata/resolve/world/region/hello.proto

--- a/util/resolver.go
+++ b/util/resolver.go
@@ -1,0 +1,215 @@
+package util
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+)
+
+// ASTNode is a type from the descriptor package.
+type ASTNode interface{}
+
+// ASTNamedNode is a type from the descriptor package that can return it's name
+// string. These include (but are not limited to):
+//
+//  *descriptor.DescriptorProto
+//  *descriptor.EnumDescriptorProto
+//  *descriptor.ServiceDescriptorProto
+//  *descriptor.FieldDescriptorProto
+//
+type ASTNamedNode interface {
+	GetName() string
+}
+
+// search searches below the given AST node for an message, enum, service, or
+// extension with the given symbol path. Valid input types are:
+//
+//  ASTNamedNode
+//  []ASTNamedNode
+//  *descriptor.FileDescriptorProto
+//
+func search(a ASTNode, symbolPath string) ASTNode {
+	// Handle the slice types.
+	rv := reflect.ValueOf(a)
+	if rv.Kind() == reflect.Slice {
+		for i := 0; i < rv.Len(); i++ {
+			if found := search(rv.Index(i).Interface(), symbolPath); found != nil {
+				return found
+			}
+		}
+		return nil
+	}
+
+	switch n := a.(type) {
+	case *descriptor.FileDescriptorProto:
+		// Note: It's important for this case to be above the ASTNamedNode case below
+		// (which only intends to match messages, enums, services and extensions) as
+		// FileDescriptorProto also implements the ASTNamedNode interface.
+
+		// Search all the top-level messages, enums, services and extensions in the
+		// file.
+		if v := search(n.MessageType, symbolPath); v != nil {
+			return v
+		}
+		if v := search(n.EnumType, symbolPath); v != nil {
+			return v
+		}
+		if v := search(n.Service, symbolPath); v != nil {
+			return v
+		}
+		if v := search(n.Extension, symbolPath); v != nil {
+			return v
+		}
+		return nil
+
+	case ASTNamedNode:
+		// Check if it's this named node.
+		if symbolPath == n.GetName() {
+			return a
+		}
+
+		// If the symbol path contains only one element (e.g. "Option") then we
+		// cannot search below this node any further, so this search failed.
+		if CountElem(symbolPath) == 1 {
+			return nil
+		}
+
+		// If it's a message type, it can have nested type declarations and
+		// enumerations, so we need to search those.
+		msg, ok := a.(*descriptor.DescriptorProto)
+		if !ok {
+			// It's an enum, service, or extension which don't have nested types.
+			return nil
+		}
+
+		// Trim one element off the symbol path, e.g. "Type.Sub" -> "Sub".
+		symbolPath = TrimElem(symbolPath, 1)
+
+		// Search nested types.
+		if v := search(msg.NestedType, symbolPath); v != nil {
+			return v
+		}
+		// Search enum types.
+		return search(msg.EnumType, symbolPath)
+
+	default:
+		panic("unexpected type")
+	}
+}
+
+// Resolver handles the resolution of symbol names to their respective files (it
+// answers the question "which file was this symbol defined in?").
+type Resolver struct {
+	f []*descriptor.FileDescriptorProto
+}
+
+// ResolveFile resolves the file that the given symbol is declared inside of, or
+// nil if it is not. It is short-handed for:
+//
+//  _, file := r.Resolve(symbolPath)
+//
+func (r *Resolver) ResolveFile(symbolPath string, relative ASTNode) *descriptor.FileDescriptorProto {
+	_, file := r.Resolve(symbolPath, relative)
+	return file
+}
+
+// ResolveSymbol resolves the symbol with the given path, or nil of it cannot be
+// resolved. It is short-handed for:
+//
+//  node, _ := r.Resolve(symbolPath)
+//
+func (r *Resolver) ResolveSymbol(symbolPath string, relative ASTNode) ASTNode {
+	node, _ := r.Resolve(symbolPath, relative)
+	return node
+}
+
+// Resolve resolves the named symbol into it's actual AST node and the file that
+// node is inside of. Example symbolPath strings are:
+//
+//  Sym
+//  pkg.Sym
+//  foo.bar.pkg.Sym
+//  .foo.bar.pkg.Sym
+//
+// Relative symbol paths like:
+//
+//  Sym
+//  pkg.Sym
+//  foo.bar.Pkg.Sym
+//
+// Are resolved according to the protobuf language doc:
+//
+//  "Packages and Name Resolution" - https://developers.google.com/protocol-buffers/docs/proto#packages
+//
+// As all relative symbol paths in protobuf follow C++ style scoping rules, the
+// path can only be resolved reliably whilst knowing the AST node that
+// resolution is relative to. If the relative node is nil and the symbol path is
+// not fully-qualified, a panic will occur.
+//
+// For example in the pseudo-code:
+//
+//  package pkg;
+//
+//  message Foo {
+//      ...
+//  }
+//
+//  message Bar {
+//      message Foo {
+//          ...
+//      }
+//
+//      Foo this = 1;
+//  }
+//
+// Resolution of the message field pkg.Bar.this must be done *relative* to the
+// AST node for pkg.Bar, because pkg.Bar.thi sis of type pkg.Bar.Foo, not
+// pkg.Foo.
+//
+// TODO(slimsag): relative symbol path resolution is not yet implemented and as
+// such will always panic.
+func (r *Resolver) Resolve(symbolPath string, relative ASTNode) (ASTNode, *descriptor.FileDescriptorProto) {
+	if !IsFullyQualified(symbolPath) {
+		panic("resolution of relative (non-fully-qualified) symbol paths is not implemented")
+	}
+	symbolPath = strings.TrimPrefix(symbolPath, ".")
+
+	// Determine the package that symbolPath is part of, considering multiple
+	// matches like these:
+	//
+	//  symbolPath="foo.bar.pkg.Sym" && GetPackage() == "foo"
+	//  symbolPath="foo.bar.pkg.Sym" && GetPackage() == "foo.bar"
+	//
+	for _, f := range r.f {
+		pkg := PackageName(f)
+		if len(pkg) == 0 {
+			panic("no package name")
+		}
+		if !strings.HasPrefix(symbolPath, pkg) {
+			continue // not a match
+		}
+
+		// Trim the package prefix off the symbol, for example:
+		//
+		//  symbolPath = "world.buildings.Options"
+		//  pkg = "world.buildings"
+		//  CountElem(pkg) == 2
+		//  TrimElem(symbolPath, CountElem(pkg)) == "Options"
+		//
+		// Use a temporary variable as we don't want it to affect the next iteration
+		// of this loop.
+		tmp := TrimElem(symbolPath, CountElem(pkg))
+
+		// Search for the symbol inside this file.
+		if n := search(ASTNode(f), tmp); n != nil {
+			return n, f
+		}
+	}
+	return nil, nil
+}
+
+// NewResolver returns a new symbol resolver for the given files.
+func NewResolver(f []*descriptor.FileDescriptorProto) *Resolver {
+	return &Resolver{f: f}
+}

--- a/util/resolver.go
+++ b/util/resolver.go
@@ -10,7 +10,7 @@ import (
 // ASTNode is a type from the descriptor package.
 type ASTNode interface{}
 
-// ASTNamedNode is a type from the descriptor package that can return it's name
+// ASTNamedNode is a type from the descriptor package that can return its name
 // string. These include (but are not limited to):
 //
 //  *descriptor.DescriptorProto
@@ -124,7 +124,7 @@ func (r *Resolver) ResolveSymbol(symbolPath string, relative ASTNode) ASTNode {
 	return node
 }
 
-// Resolve resolves the named symbol into it's actual AST node and the file that
+// Resolve resolves the named symbol into its actual AST node and the file that
 // node is inside of. Example symbolPath strings are:
 //
 //  Sym

--- a/util/resolver_test.go
+++ b/util/resolver_test.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"testing"
+)
+
+// Fully-qualified symbol path resolution tests.
+func TestResolverFQ(t *testing.T) {
+	tests := map[string]string{
+		".world.building.Options": "world/region/building.proto",
+		".world.human.Options":    "world/region/human.proto",
+	}
+
+	req, err := ReadJSONFile("testdata/resolver.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := NewResolver(req.ProtoFile)
+	for symbolPath, want := range tests {
+		got := resolver.ResolveFile(symbolPath, nil).GetName()
+		if got != want {
+			t.Logf("symbolPath=%q\n", symbolPath)
+			t.Fatalf("got %q want %q", got, want)
+		}
+	}
+}

--- a/util/testdata/resolve/world/region/building.proto
+++ b/util/testdata/resolve/world/region/building.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package world.building;
+
+message Options {
+	bool HasRoof = 1;
+}

--- a/util/testdata/resolve/world/region/hello.proto
+++ b/util/testdata/resolve/world/region/hello.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+import "world/region/human.proto";
+import "world/region/building.proto";
+
+message Hello {
+	string name = 1;
+  world.human.Options options = 2;
+	world.building.Options building = 3;
+}

--- a/util/testdata/resolve/world/region/human.proto
+++ b/util/testdata/resolve/world/region/human.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package world.human;
+
+message Options {
+	bool HasHair = 1;
+}

--- a/util/testdata/resolver.json
+++ b/util/testdata/resolver.json
@@ -1,0 +1,579 @@
+{
+  "file_to_generate": [
+    "world/region/hello.proto"
+  ],
+  "parameter": "out=resolver.json",
+  "proto_file": [
+    {
+      "name": "world/region/human.proto",
+      "package": "world.human",
+      "message_type": [
+        {
+          "name": "Options",
+          "field": [
+            {
+              "name": "HasHair",
+              "number": 1,
+              "label": 1,
+              "type": 8
+            }
+          ]
+        }
+      ],
+      "source_code_info": {
+        "location": [
+          {
+            "span": [
+              0,
+              0,
+              6,
+              1
+            ]
+          },
+          {
+            "path": [
+              2
+            ],
+            "span": [
+              2,
+              8,
+              19
+            ]
+          },
+          {
+            "path": [
+              4,
+              0
+            ],
+            "span": [
+              4,
+              0,
+              6,
+              1
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              1
+            ],
+            "span": [
+              4,
+              8,
+              15
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0
+            ],
+            "span": [
+              5,
+              8,
+              25
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0,
+              4
+            ],
+            "span": [
+              5,
+              8,
+              4,
+              17
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0,
+              5
+            ],
+            "span": [
+              5,
+              8,
+              12
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0,
+              1
+            ],
+            "span": [
+              5,
+              13,
+              20
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0,
+              3
+            ],
+            "span": [
+              5,
+              23,
+              24
+            ]
+          }
+        ]
+      },
+      "syntax": "proto3"
+    },
+    {
+      "name": "world/region/building.proto",
+      "package": "world.building",
+      "message_type": [
+        {
+          "name": "Options",
+          "field": [
+            {
+              "name": "HasRoof",
+              "number": 1,
+              "label": 1,
+              "type": 8
+            }
+          ]
+        }
+      ],
+      "source_code_info": {
+        "location": [
+          {
+            "span": [
+              0,
+              0,
+              6,
+              1
+            ]
+          },
+          {
+            "path": [
+              2
+            ],
+            "span": [
+              2,
+              8,
+              22
+            ]
+          },
+          {
+            "path": [
+              4,
+              0
+            ],
+            "span": [
+              4,
+              0,
+              6,
+              1
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              1
+            ],
+            "span": [
+              4,
+              8,
+              15
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0
+            ],
+            "span": [
+              5,
+              8,
+              25
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0,
+              4
+            ],
+            "span": [
+              5,
+              8,
+              4,
+              17
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0,
+              5
+            ],
+            "span": [
+              5,
+              8,
+              12
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0,
+              1
+            ],
+            "span": [
+              5,
+              13,
+              20
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0,
+              3
+            ],
+            "span": [
+              5,
+              23,
+              24
+            ]
+          }
+        ]
+      },
+      "syntax": "proto3"
+    },
+    {
+      "name": "world/region/hello.proto",
+      "dependency": [
+        "world/region/human.proto",
+        "world/region/building.proto"
+      ],
+      "message_type": [
+        {
+          "name": "Hello",
+          "field": [
+            {
+              "name": "name",
+              "number": 1,
+              "label": 1,
+              "type": 9
+            },
+            {
+              "name": "options",
+              "number": 2,
+              "label": 1,
+              "type": 11,
+              "type_name": ".world.human.Options"
+            },
+            {
+              "name": "building",
+              "number": 3,
+              "label": 1,
+              "type": 11,
+              "type_name": ".world.building.Options"
+            }
+          ]
+        }
+      ],
+      "source_code_info": {
+        "location": [
+          {
+            "span": [
+              0,
+              0,
+              9,
+              1
+            ]
+          },
+          {
+            "path": [
+              3,
+              0
+            ],
+            "span": [
+              2,
+              7,
+              33
+            ]
+          },
+          {
+            "path": [
+              3,
+              1
+            ],
+            "span": [
+              3,
+              7,
+              36
+            ]
+          },
+          {
+            "path": [
+              4,
+              0
+            ],
+            "span": [
+              5,
+              0,
+              9,
+              1
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              1
+            ],
+            "span": [
+              5,
+              8,
+              13
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0
+            ],
+            "span": [
+              6,
+              8,
+              24
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0,
+              4
+            ],
+            "span": [
+              6,
+              8,
+              5,
+              15
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0,
+              5
+            ],
+            "span": [
+              6,
+              8,
+              14
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0,
+              1
+            ],
+            "span": [
+              6,
+              15,
+              19
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              0,
+              3
+            ],
+            "span": [
+              6,
+              22,
+              23
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              1
+            ],
+            "span": [
+              7,
+              2,
+              34
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              1,
+              4
+            ],
+            "span": [
+              7,
+              2,
+              6,
+              24
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              1,
+              6
+            ],
+            "span": [
+              7,
+              2,
+              21
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              1,
+              1
+            ],
+            "span": [
+              7,
+              22,
+              29
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              1,
+              3
+            ],
+            "span": [
+              7,
+              32,
+              33
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              2
+            ],
+            "span": [
+              8,
+              8,
+              44
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              2,
+              4
+            ],
+            "span": [
+              8,
+              8,
+              7,
+              34
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              2,
+              6
+            ],
+            "span": [
+              8,
+              8,
+              30
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              2,
+              1
+            ],
+            "span": [
+              8,
+              31,
+              39
+            ]
+          },
+          {
+            "path": [
+              4,
+              0,
+              2,
+              2,
+              3
+            ],
+            "span": [
+              8,
+              42,
+              43
+            ]
+          }
+        ]
+      },
+      "syntax": "proto3"
+    }
+  ]
+}

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,8 @@
 package util // import "sourcegraph.com/sourcegraph/prototools/util"
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"path"
 	"strings"
 
@@ -158,4 +160,22 @@ func PackageName(f *descriptor.FileDescriptorProto) string {
 	// protobuf only speaks in unix path terms).
 	pkg := path.Base(f.GetName())
 	return strings.TrimSuffix(pkg, path.Ext(pkg))
+}
+
+// ReadJSONFile opens and unmarshals the JSON dump file from the protoc-gen-json
+// plugin, returning any error that occurs.
+func ReadJSONFile(path string) (*plugin.CodeGeneratorRequest, error) {
+	// Read the file.
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the request.
+	r := &plugin.CodeGeneratorRequest{}
+	err = json.Unmarshal(data, r)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
 }


### PR DESCRIPTION
This change fixes links to symbols in the documentation. Prior to this change links _did work_ but only partially, failing on corner-cases.

This was supposed to be fixed in #2 and #3 (both of which were closed by me as they weren't the right approach).

This approach should be correct and in-line with the Protobuf language specification (see `Resolver.Resolve` comments).

Although the resolver implementation does not yet handle relative symbol paths, the API is prepared to and long-term I plan to implement it. I have yet to actually run into any protobuf files that need relative symbol paths (it appears that `protoc` does some resolution for us before handing the data off to us).

At the very least, this makes all message/enum/service/etc types inside our docs clickable today and have nice URLs.