### PR TITLE
Render nested types

### DIFF
--- a/templates/tmpl.html
+++ b/templates/tmpl.html
@@ -66,14 +66,15 @@
 	{{end}}
 
 	<!-- Enumerations -->
-	{{if .EnumType}}
+	{{$enums := AllEnums . true}}
+	{{if $enums}}
 		<div class="doc-enum-types">
 			<h1>Enums</h1>
-			{{range $e := .EnumType}}
+			{{range $e := $enums}}
 				<div class="doc-inner">
 					<h2 id="{{$e.Name}}">Enum: {{$e.Name}}</h2>
 					{{template "CommentsParagraph" $e}}
-					{{if .Value}}
+					{{if $e.Value}}
 						<table>
 							<tr><td>Name</td><td>Value</td><td>Description</td></tr>
 							{{range .Value}}
@@ -132,10 +133,11 @@
 	{{end}}
 
 	<!-- Messages -->
-	{{if .MessageType}}
+	{{$messages := AllMessages . true}}
+	{{if $messages}}
 		<div class="doc-message-types">
 			<h1>Messages</h1>
-			{{range $m := .MessageType}}
+			{{range $m := $messages}}
 				<div class="doc-inner">
 					<h2 id="{{$m.Name}}">Message: {{$m.Name}}</h2>
 					{{template "CommentsParagraph" $m}}

--- a/tmpl/util.go
+++ b/tmpl/util.go
@@ -72,11 +72,13 @@ type tmplFuncs struct {
 // funcMap returns the function map for feeding into templates.
 func (f *tmplFuncs) funcMap() template.FuncMap {
 	return map[string]interface{}{
-		"cleanLabel": f.cleanLabel,
-		"cleanType":  f.cleanType,
-		"fieldType":  f.fieldType,
-		"urlToType":  f.urlToType,
-		"location":   f.location,
+		"cleanLabel":  f.cleanLabel,
+		"cleanType":   f.cleanType,
+		"fieldType":   f.fieldType,
+		"urlToType":   f.urlToType,
+		"location":    f.location,
+		"AllMessages": util.AllMessages,
+		"AllEnums":    util.AllEnums,
 	}
 }
 

--- a/util/all.go
+++ b/util/all.go
@@ -1,0 +1,121 @@
+package util
+
+import (
+	"fmt"
+
+	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
+)
+
+// nameMessage names the given message descriptor, returning a copy with the
+// Name pointer replaced with &newName.
+func nameMessage(old *descriptor.DescriptorProto, newName string) *descriptor.DescriptorProto {
+	cpy := *old
+	cpy.Name = &newName
+	return &cpy
+}
+
+// nameEnum names the given enum descriptor, returning a copy with the Name0
+// pointer replaced with &newName.
+func nameEnum(old *descriptor.EnumDescriptorProto, newName string) *descriptor.EnumDescriptorProto {
+	cpy := *old
+	cpy.Name = &newName
+	return &cpy
+}
+
+// appendEnum is a helper function for appending two symbol paths together. It's
+// not generic enough to be public (i.e. it can only work for the below use
+// cases).
+func appendElem(symbolPath, childName string) string {
+	if symbolPath == "" {
+		return childName + "."
+	}
+	return fmt.Sprintf("%s.%s", symbolPath, childName)
+}
+
+// AllMessages returnes a list of all the message type nodes in f, including
+// nested ones.
+func AllMessages(f *descriptor.FileDescriptorProto, swapNames bool) []*descriptor.DescriptorProto {
+	var (
+		all        []*descriptor.DescriptorProto
+		walk       func(n *descriptor.DescriptorProto)
+		symbolPath string
+	)
+
+	// Define the function that will perform the recursive walk of the AST nodes.
+	walk = func(n *descriptor.DescriptorProto) {
+		// The name of the type should only ever be a single element.
+		if CountElem(n.GetName()) != 1 {
+			panic("unexpected name elements")
+		}
+
+		for _, child := range n.NestedType {
+			// Accumulate the node and swap the names of it, if desired.
+			if swapNames {
+				all = append(all, nameMessage(child, symbolPath+child.GetName()))
+			} else {
+				all = append(all, child)
+			}
+
+			symbolPath = appendElem(symbolPath, child.GetName()) // push parent type name
+			walk(child)                                          // walk nested types, recursively
+			symbolPath = TrimElem(symbolPath, 1)                 // pop parent type name
+		}
+	}
+
+	for _, m := range f.MessageType {
+		// Accumulate each root-level message type.
+		all = append(all, m)
+
+		symbolPath = appendElem(symbolPath, m.GetName()) // push parent type name
+		walk(m)                                          // walk nested types
+		symbolPath = TrimElem(symbolPath, 1)             // pop parent type name
+	}
+	return all
+}
+
+// AllEnums returnes a list of all the enum type nodes in f, including nested
+// ones.
+func AllEnums(f *descriptor.FileDescriptorProto, swapNames bool) []*descriptor.EnumDescriptorProto {
+	var (
+		all        []*descriptor.EnumDescriptorProto
+		walk       func(n *descriptor.DescriptorProto)
+		symbolPath string
+	)
+
+	// Define the function that will perform the recursive walk of the AST nodes.
+	walk = func(n *descriptor.DescriptorProto) {
+		// The name of the type should only ever be a single element.
+		if CountElem(n.GetName()) != 1 {
+			panic("unexpected name elements")
+		}
+
+		for _, child := range n.EnumType {
+			// Accumulate the node, swapping the names of it if desired.
+			if swapNames {
+				child = nameEnum(child, symbolPath+child.GetName())
+			}
+			all = append(all, child)
+		}
+
+		// Walk the nested types for this message node, in case there are more child
+		// enum types.
+		for _, child := range n.NestedType {
+			symbolPath = appendElem(symbolPath, child.GetName()) // push parent type name
+			walk(child)                                          // walk nested types, recursively
+			symbolPath = TrimElem(symbolPath, 1)                 // pop parent type name
+		}
+	}
+
+	// Accumulate each root-level enum type.
+	for _, e := range f.EnumType {
+		all = append(all, e)
+	}
+
+	// Walk each root-level message type for nested enums.
+	for _, m := range f.MessageType {
+		symbolPath = appendElem(symbolPath, m.GetName()) // push parent type name
+		walk(m)                                          // walk nested types, recursively
+		symbolPath = TrimElem(symbolPath, 1)             // pop parent type name
+	}
+	return all
+}


### PR DESCRIPTION
This change adds two utility functions for (recursively) accumulating the message and enumeration types. These come from the fact that enums and messages can be declared recursively inside message types (as described in the language spec).

I think the code is as clean-and-concise as it can be, but I still want to add tests sometime next week due to the nature of the problem. I'll add those sometime next week. I can confirm it's working for at least dual-depth enumerations and messages, though.

See #4 for more details.