### PR TITLE
Add support for templated XML filemaps

### DIFF
--- a/README.doc.md
+++ b/README.doc.md
@@ -29,10 +29,123 @@ Would produce documentation for `file.proto` inside the `doc/` directory using t
 
 ## Options
 
-| Option     | Default                     | Description                                                        |
-|------------|-----------------------------|--------------------------------------------------------------------|
-| `template` | `templates/tmpl.html`       | Input `.html` `text/template` template file to use for generation. |
-| `root`     | (current working directory) | Root directory path to prefix all generated URLs with.             |
+| Option         | Default                     | Description                                                        |
+|----------------|-----------------------------|--------------------------------------------------------------------|
+| `template`     | `templates/tmpl.html`       | Input `.html` `html/template` template file to use for generation. |
+| `root`         | (current working directory) | Root directory path to prefix all generated URLs with.             |
+| `filemap`      | none                        | A XML filemap, which specifies how output files are generated.     |
+| `dump-filemap` | none                        | Dump the executed filemap template to the given filepath.          |
+
+The `template` and `filemap` options are exclusive (only one may be used at a time).
+
+## Templates
+
+Template files are standard Go `html/template` files, and as such their documentation can be found [in that package](https://golang.org/pkg/html/template).
+
+## File Maps
+
+In many cases producing a single output `.html` file for a single input `.proto` file is not desired, often producing very verbose or long web pages. Because protoc-gen-doc doesn't really know how you want your documentation laid out on the file-system (and does not want to restrict you), we offer templated XML file maps.
+
+Say for example that we wanted to produce documentation for three gRPC services, all of which are declared inside of a `organization/services.proto` file:
+
+- "Producer" -> `out_dir/organization/service-producer.html`
+- "Consumer" -> `out_dir/organization/service-consumer.html`
+- "Trader"   -> `out_dir/organization/service-trader.html`
+
+And also an `out_dir/index.html` file which will link to the three services.
+
+In order to produce the above three (plus index) files for the single `services.proto` file, we will use an XML filemap that follows the syntax of:
+
+```
+<FileMap>
+    <Generate>
+        <Template>path/to/template.html</Template>
+        <Target>path/to/target.proto</Target> <!-- optional -->
+        <Output>path/to/output.html</Output>
+        <Includes>
+            <Include>a.tmpl</Include>
+            <Include>b.tmpl</Include>
+        </Includes>
+        <Data>
+            <Item><Key>myKey1</Key><Value>myValue1</Value></Item>
+            <Item><Key>myKey2</Key><Value>myValue2</Value></Item>
+        </Data>
+    </Generate>
+    <Generate>
+        ...
+    </Generate>
+</FileMap>
+```
+
+Where `<Template>` and `<Include>` paths are relative to the XML filemap directory, `<Output>` paths are relative to the output directory, and `<Target>` paths are relative to `--proto_path` directories.
+
+Thus we would write:
+
+```
+<FileMap>
+    <!-- Index Page (notice the lack of target tag) -->
+    <Generate>
+        <Template>index.html</Template>
+        <Output>index.html</Output>
+    </Generate>
+
+    <!-- Service Pages -->
+    <Generate>
+        <Template>service.html</Template>
+        <Target>organization/services.proto</Target>
+        <Output>organization/service-producer.html</Output>
+        <Data>
+            <Item><Key>Service</Key><Value>Producer</Value></Item>
+        </Data>
+    </Generate>
+    <Generate>
+        <Template>service.html</Template>
+        <Target>organization/services.proto</Target>
+        <Output>organization/service-consumer.html</Output>
+        <Data>
+            <Item><Key>Service</Key><Value>Consumer</Value></Item>
+        </Data>
+    </Generate>
+    <Generate>
+        <Template>service.html</Template>
+        <Target>organization/services.proto</Target>
+        <Output>organization/service-trader.html</Output>
+        <Data>
+            <Item><Key>Service</Key><Value>Trader</Value></Item>
+        </Data>
+    </Generate>
+</FileMap>
+```
+
+As you can see, for just three types it quickly becomes very cumbersome. For this reason filemaps _are themselves templates_ (this is also the rational for choosing XML over e.g. JSON), so we can write the above instead using `html/template` syntax:
+
+```
+<FileMap>
+    <!-- Index Page (notice the lack of target tag) -->
+    <Generate>
+        <Template>index.html</Template>
+        <Output>index.html</Output>
+    </Generate>
+
+{{$serviceTemplate := "service.html"}}
+{{range $f := .ProtoFile}}
+    {{range $s := .Service}}
+        <Generate>
+            <Template>{{$serviceTemplate}}</Template>
+            <Target>{{$f.Name}}</Target>
+            <Output>{{dir $f.Name}}/{{$s.Name}}{{ext $serviceTemplate}}</Output>
+            <Data>
+                <Item><Key>Service</Key><Value>{{$s.Name}}</Value></Item>
+            </Data>
+        </Generate>
+    {{end}}
+{{end}}
+</FileMap>
+```
+
+Which is to say: for every service type (`range $s := .Service`) in every protobuf input file (`range $f := .ProtoFile` and `<Target>{{$f.Name}}</Target>`) generate a output file using the Go `html/template` (`{{$serviceTemplate}}`) placing output in the directory the protobuf file is in (`{{$f.Name}}`, `organization` in our example), with the service types name (`{{$s.Name}}`, or `Producer` `Consumer` `Trader` above) with the extension of the `$serviceTemplate` file (`.html`), and when each `<Template>` is executed pass along a map with the given keys/values (the service template can then selectively render _just that service type_).
+
+For debugging purposes, you can use the `dump-filemap` option which will execute the template and dump the resulting XML out to a file.
 
 ## Issues
 

--- a/templates/common.html
+++ b/templates/common.html
@@ -1,0 +1,53 @@
+{{define "Comments"}}
+	{{$l := location .}}
+	{{if $l}}
+		{{if or $l.LeadingComments $l.TrailingComments}}
+			{{with $l.LeadingComments}}{{.}}{{end}}
+			{{with $l.TrailingComments}}{{.}}{{end}}
+		{{end}}
+	{{end}}
+{{end}}
+
+{{define "CommentsParagraph"}}
+	{{$l := location .}}
+	{{if $l}}
+		{{if or $l.LeadingComments $l.TrailingComments}}
+			<p class="description">Description:&nbsp;
+					{{with $l.LeadingComments}}{{.}}{{end}}
+					{{with $l.TrailingComments}}{{.}}{{end}}
+			</p>
+		{{end}}
+	{{end}}
+{{end}}
+
+{{define "Package"}}
+    <h1>{{.Package}}</h1>
+    <div class="doc-inner">
+        <p>
+            <code>{{.Name}}</code> (syntax: <code>{{with .Syntax}}{{.}}{{else}}proto2{{end}}</code>)
+        </p>
+    </div>
+{{end}}
+
+<style>
+.doc table, .doc tr, .doc td, .doc th {
+	margin: 0;
+	padding: 0;
+	border-collapse: collapse;
+}
+
+.doc table {
+	margin-left: 1em;
+}
+
+.doc td {
+	padding: 1em;
+	padding-top: .3em;
+	padding-bottom: .3em;
+	border-bottom: 1px solid black;
+}
+
+.doc-inner {
+	margin-left: 1em;
+}
+</style>

--- a/templates/filemap.xml
+++ b/templates/filemap.xml
@@ -1,0 +1,32 @@
+<FileMap>
+    <!-- Index page -->
+    <Generate>
+        <Template>index.html</Template>
+        <Output>index.html</Output>
+    </Generate>
+
+{{$templatePath := "tmpl.html"}}
+{{$serviceTemplate := "service.html"}}
+{{range $f := .ProtoFile}}
+    <!-- Main page for each proto file -->
+    <Generate>
+        <Template>{{$templatePath}}</Template>
+        <Target>{{$f.Name}}</Target>
+        <Output>{{trimExt $f.Name}}{{ext $templatePath}}</Output>
+        <Includes><Include>common.html</Include></Includes>
+    </Generate>
+
+    <!-- Page for each service in proto file -->
+    {{range $s := .Service}}
+        <Generate>
+            <Template>{{$serviceTemplate}}</Template>
+            <Target>{{$f.Name}}</Target>
+            <Output>{{dir $f.Name}}/{{$s.Name}}{{ext $serviceTemplate}}</Output>
+            <Includes><Include>common.html</Include></Includes>
+            <Data>
+                <Item><Key>Service</Key><Value>{{$s.Name}}</Value></Item>
+            </Data>
+        </Generate>
+    {{end}}
+{{end}}
+</FileMap>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,8 @@
+{{$last := (len .ProtoFile)}}
+{{$last := sub $last 1}}
+
+{{with index .ProtoFile $last}}
+    <h1>{{.Package}} Protocol</h1>
+    <p>Generated documentation for the {{.Package}} protocol.</p>
+    <p><a href="{{trimExt .Name}}.html">View the documentation</a></p>
+{{end}}

--- a/templates/service.html
+++ b/templates/service.html
@@ -1,0 +1,29 @@
+{{template "common.html"}}
+
+<div class="doc">
+	{{template "Package" .}}
+
+	<div class="doc-inner">
+		{{range $s := .Service}}
+			{{if eq $s.GetName $.Data.Service}}
+				<h1>{{$s.Name}}</h1>
+				{{template "CommentsParagraph" $s}}
+				<table>
+					<tr><td>Method</td><td>Input Type</td><td>Output Type</td><td>Description</td></tr>
+					{{range $s.Method}}
+						<tr>
+							<td>{{.Name}}
+								{{if .ClientStreaming}}*Client-Streaming {{end}}
+								{{if .ServerStreaming}}*Server-Streaming {{end}}
+								{{if .Options}}{{if .Options.Deprecated}}*Deprecated{{end}}{{end}}
+							</td>
+							<td><a href="{{urlToType .InputType}}">{{cleanType .InputType}}</a></td>
+							<td><a href="{{urlToType .OutputType}}">{{cleanType .OutputType}}</a></td>
+							<td>{{template "Comments" .}}</td>
+						</tr>
+					{{end}}
+				</table>
+			{{end}}
+		{{end}}
+	</div>
+</div>

--- a/templates/tmpl.html
+++ b/templates/tmpl.html
@@ -1,55 +1,7 @@
-{{define "Comments"}}
-	{{$l := location .}}
-	{{if $l}}
-		{{if or $l.LeadingComments $l.TrailingComments}}
-			{{with $l.LeadingComments}}{{.}}{{end}}
-			{{with $l.TrailingComments}}{{.}}{{end}}
-		{{end}}
-	{{end}}
-{{end}}
-
-{{define "CommentsParagraph"}}
-	{{$l := location .}}
-	{{if $l}}
-		{{if or $l.LeadingComments $l.TrailingComments}}
-			<p class="description">Description:&nbsp;
-					{{with $l.LeadingComments}}{{.}}{{end}}
-					{{with $l.TrailingComments}}{{.}}{{end}}
-			</p>
-		{{end}}
-	{{end}}
-{{end}}
-
-<style>
-.doc table, .doc tr, .doc td, .doc th {
-	margin: 0;
-	padding: 0;
-	border-collapse: collapse;
-}
-
-.doc table {
-	margin-left: 1em;
-}
-
-.doc td {
-	padding: 1em;
-	padding-top: .3em;
-	padding-bottom: .3em;
-	border-bottom: 1px solid black;
-}
-
-.doc-inner {
-	margin-left: 1em;
-}
-</style>
+{{template "common.html"}}
 
 <div class="doc">
-	<h1>{{.Package}}</h1>
-	<div class="doc-inner">
-		<p>
-			<code>{{.Name}}</code> (syntax: <code>{{with .Syntax}}{{.}}{{else}}proto2{{end}}</code>)
-		</p>
-	</div>
+	{{template "Package" .}}
 
 	<!-- Dependencies -->
 	{{if .Dependency}}
@@ -66,7 +18,7 @@
 	{{end}}
 
 	<!-- Enumerations -->
-	{{$enums := AllEnums . true}}
+	{{$enums := AllEnums true}}
 	{{if $enums}}
 		<div class="doc-enum-types">
 			<h1>Enums</h1>
@@ -110,30 +62,14 @@
 			<h1>Services</h1>
 			{{range $s := .Service}}
 				<div class="doc-inner">
-					<h2 id="{{$s.Name}}">Service: {{$s.Name}}</h2>
-					{{template "CommentsParagraph" $s}}
-					<table>
-						<tr><td>Method</td><td>Input Type</td><td>Output Type</td><td>Description</td></tr>
-						{{range $s.Method}}
-							<tr>
-								<td>{{.Name}}
-									{{if .ClientStreaming}}*Client-Streaming {{end}}
-									{{if .ServerStreaming}}*Server-Streaming {{end}}
-									{{if .Options}}{{if .Options.Deprecated}}*Deprecated{{end}}{{end}}
-								</td>
-								<td><a href="{{urlToType .InputType}}">{{cleanType .InputType}}</a></td>
-								<td><a href="{{urlToType .OutputType}}">{{cleanType .OutputType}}</a></td>
-								<td>{{template "Comments" .}}</td>
-							</tr>
-						{{end}}
-					</table>
+					<h2 id="{{$s.Name}}">Service: <a href="{{$s.Name}}.html">{{$s.Name}}</a></h2>
 				</div>
 			{{end}}
 		</div>
 	{{end}}
 
 	<!-- Messages -->
-	{{$messages := AllMessages . true}}
+	{{$messages := AllMessages true}}
 	{{if $messages}}
 		<div class="doc-message-types">
 			<h1>Messages</h1>

--- a/tmpl/filemap.go
+++ b/tmpl/filemap.go
@@ -1,0 +1,66 @@
+package tmpl
+
+import "path"
+
+// FileMapDataItem represents a single pair in a map.
+type FileMapDataItem struct {
+	Key   string
+	Value string
+}
+
+// FileMapGenerate represents a generate tag.
+type FileMapGenerate struct {
+	// Template is the path of the template file to use for generating the
+	// target.
+	Template string
+
+	// Target is the target proto file for generation. It must match one of the
+	// input proto files, or else the template will not be executed.
+	Target string `xml:",omitempty"`
+
+	// Output is the output file to write the executed template contents to.
+	Output string
+
+	// Include is a list of template files to include for execution of the
+	// template.
+	Include []string `xml:"Includes>Include,omitempty"`
+
+	// Data is effectively an map of items to pass onto the template during
+	// execution.
+	Data []*FileMapDataItem `xml:"Data>Item,omitempty"`
+}
+
+// DataMap returns f.Data but as a Go map. It panics if there are any duplicate
+// keys.
+func (f *FileMapGenerate) DataMap() map[string]string {
+	m := make(map[string]string, len(f.Data))
+	for _, d := range f.Data {
+		if _, ok := m[d.Key]; ok {
+			panic("duplicate data key")
+		}
+		m[d.Key] = d.Value
+	}
+	return m
+}
+
+// FileMap represents a file mapping.
+type FileMap struct {
+	// Dir is the directory to resolve template paths mentioned in the filemap
+	// relative to. It should be the directory that this file map resides inside
+	// of. The path will be converted to a unix-style one for protobuf, which
+	// only deals with unix-style paths.
+	Dir string `xml:",omitempty"`
+
+	Generate []*FileMapGenerate `xml:"Generate"`
+}
+
+// relative returns a list of relative paths prefixed with the f.Dir path (also
+// converted to a unix-style path).
+func (f *FileMap) relative(rel ...string) []string {
+	dir := unixPath(f.Dir)
+	var abs []string
+	for _, p := range rel {
+		abs = append(abs, path.Join(dir, p))
+	}
+	return abs
+}

--- a/tmpl/filemap_test.go
+++ b/tmpl/filemap_test.go
@@ -1,0 +1,68 @@
+package tmpl
+
+import (
+	"encoding/xml"
+	"reflect"
+	"testing"
+)
+
+func TestFilemap(t *testing.T) {
+	tst := `
+    <FileMap>
+        <Generate>
+            <Template>path/to/template.html</Template>
+            <Target>path/to/target.proto</Target>
+            <Output>path/to/output.html</Output>
+            <Includes>
+                <Include>a.tmpl</Include>
+                <Include>b.tmpl</Include>
+            </Includes>
+            <Data>
+                <Item>
+                    <Key>key1</Key>
+                    <Value>value1</Value>
+                </Item>
+                <Item>
+                    <Key>key2</Key>
+                    <Value>value2</Value>
+                </Item>
+                <Item>
+                    <Key>key3</Key>
+                    <Value>value3</Value>
+                </Item>
+            </Data>
+        </Generate>
+    </FileMap>
+    `
+	want := FileMap{
+		Generate: []*FileMapGenerate{
+			{
+				Template: "path/to/template.html",
+				Target:   "path/to/target.proto",
+				Output:   "path/to/output.html",
+				Include:  []string{"a.tmpl", "b.tmpl"},
+				Data: []*FileMapDataItem{
+					{Key: "key1", Value: "value1"},
+					{Key: "key2", Value: "value2"},
+					{Key: "key3", Value: "value3"},
+				},
+			},
+		},
+	}
+
+	// Verify the unmarshaled data is exactly equal.
+	var f FileMap
+	err := xml.Unmarshal([]byte(tst), &f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(f, want) {
+		// Print the XML we expect, since the test failed.
+		wantOut, err := xml.MarshalIndent(want, "", "    ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("\n%s\n", string(wantOut))
+		t.Fatal("not equal")
+	}
+}


### PR DESCRIPTION
This change adds support for templated XML filemaps; for details on what these are or why XML was chosen over e.g. JSON, please take a peek at the [updated README.doc.md](https://github.com/sourcegraph/prototools/blob/307c2759c6d21ed014f1abf0994c87651e684466/README.doc.md). or the `templates` directory.

Overall, this gives us the ability to generated e.g. static index pages and individual pages for each service/message/enum type if we desire, rather than being restricted to a 1:1 `input.proto`:`output.html` style generation process.