### PR TITLE
tmpl: add Generator GenerateOutput SetRequest methods for dynamic documentation.

### DIFF
--- a/tmpl/generator.go
+++ b/tmpl/generator.go
@@ -151,12 +151,13 @@ func (g *Generator) genTarget(gen *FileMapGenerate, userCtx interface{}) (*plugi
 
 	// Find the target proto file.
 	for _, v := range protoFile {
-		for _, gen := range g.FileMap.Generate {
-			if gen.Target == f.GetName() {
-				f = v
-				break
-			}
+		if gen.Target == v.GetName() {
+			f = v
+			break
 		}
+	}
+	if f == nil {
+		return nil, fmt.Errorf("no input proto file for generator target %q", gen.Target)
 	}
 
 	// Prepare the generators template.

--- a/tmpl/generator.go
+++ b/tmpl/generator.go
@@ -142,6 +142,8 @@ func New() *Generator {
 	}
 }
 
+// genTarget a filemap generator with a specific target (e.g. for individual doc
+// pages).
 func (g *Generator) genTarget(gen *FileMapGenerate, userCtx interface{}) (*plugin.CodeGeneratorResponse_File, error) {
 	var (
 		buf       = bytes.NewBuffer(nil)


### PR DESCRIPTION
This change allows the use of the package in combination with any `*plugin.CodeGeneratorRequest` (e.g. JSON loaded from `cmd/protoc-gen-json`) to provide dynamic (i.e. context-specific) generation of documentation.

- Make `Generator.Request` field private, it now needs to be set explicitly via the new `SetRequest` method.
- Do not recreate the grpc-gateway `*Registry` upon each generation.
- Factor out the target-based and target-less generation code in `Generate` into separate `genTarget` and `genNoTarget` methods, respectively.
- Add a `GenerateOutput` method for generating an explicit output file with input template data (`ctx`). This lets users of the package provide dynamic documentation should they choose, rather than having a strict requirement that all docs be generated up-front.