### PR TITLE
protoc-gen-doc: Fix panic parsing input.

### DIFF
--- a/cmd/protoc-gen-doc/main.go
+++ b/cmd/protoc-gen-doc/main.go
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	// Unmarshal the protoc generation request.
-	var request *plugin.CodeGeneratorRequest
+	request := &plugin.CodeGeneratorRequest{}
 	if err := proto.Unmarshal(data, request); err != nil {
 		log.Fatal(err, ": failed to parse input proto")
 	}

--- a/tmpl/generator.go
+++ b/tmpl/generator.go
@@ -141,7 +141,6 @@ func (g *Generator) SetRequest(r *plugin.CodeGeneratorRequest) error {
 // New returns a new generator for the given template.
 func New() *Generator {
 	return &Generator{
-		request:  &plugin.CodeGeneratorRequest{},
 		response: &plugin.CodeGeneratorResponse{},
 		registry: gateway.NewRegistry(),
 	}


### PR DESCRIPTION
Provide a non-nil message to proto.Unmarshal. It calls Reset() on the
message so it cannot be nil.

Fixes #10.