### PR TITLE
tmpl: Support vendored instances of protoc-gen-go/descriptor.

### DIFF
--- a/tmpl/util.go
+++ b/tmpl/util.go
@@ -296,7 +296,9 @@ func (f *tmplFuncs) resolvePkgPath(pkg string) string {
 func (f *tmplFuncs) location(x interface{}) *descriptor.SourceCodeInfo_Location {
 	// Validate that we got a sane type from the template.
 	pkgPath := reflect.Indirect(reflect.ValueOf(x)).Type().PkgPath()
-	if pkgPath != "" && pkgPath != "github.com/golang/protobuf/protoc-gen-go/descriptor" {
+	if pkgPath != "" && pkgPath != "github.com/golang/protobuf/protoc-gen-go/descriptor" &&
+		!strings.HasSuffix(pkgPath, "/vendor/github.com/golang/protobuf/protoc-gen-go/descriptor") {
+
 		panic("expected descriptor type; got " + fmt.Sprintf("%q", pkgPath))
 	}
 


### PR DESCRIPTION
This is needed when this package is vendored via Go 1.6 /vendor/ support.

The `PkgPath` returned value does not strip /vendor/ prefix, as documented in https://github.com/golang/go/issues/12739.