### PR TITLE
Remove use of ioutil package

### DIFF
--- a/cmd/protoc-gen-doc/main.go
+++ b/cmd/protoc-gen-doc/main.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"go/build"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -73,7 +72,7 @@ func main() {
 	g := tmpl.New()
 
 	// Read input from the protoc compiler.
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatal(err, ": failed to read input")
 	}
@@ -95,7 +94,7 @@ func main() {
 
 	// Handle configuration files.
 	if conf, ok := params["conf"]; ok {
-		confData, err := ioutil.ReadFile(conf)
+		confData, err := os.ReadFile(conf)
 		if err != nil {
 			log.Fatal(err, ": could not read conf file")
 		}
@@ -116,7 +115,7 @@ func main() {
 		fileMapData = fmt.Sprintf(basicFileMap, paramTemplate)
 	} else if haveFileMap {
 		// Load the filemap template.
-		data, err := ioutil.ReadFile(paramFileMap)
+		data, err := os.ReadFile(paramFileMap)
 		if err != nil {
 			log.Fatal(err, ": failed to read file map")
 		}

--- a/cmd/protoc-gen-dump/main.go
+++ b/cmd/protoc-gen-dump/main.go
@@ -13,7 +13,6 @@ package main // import "sourcegraph.com/sourcegraph/prototools/cmd/protoc-gen-du
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -28,7 +27,7 @@ func main() {
 	log.SetPrefix("protoc-gen-proto: ")
 
 	// Read input from the protoc compiler.
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatal(err, ": failed to read input")
 	}

--- a/cmd/protoc-gen-json/main.go
+++ b/cmd/protoc-gen-json/main.go
@@ -14,7 +14,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -29,7 +28,7 @@ func main() {
 	log.SetPrefix("protoc-gen-json: ")
 
 	// Read input from the protoc compiler.
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatal(err, ": failed to read input")
 	}

--- a/tmpl/generator.go
+++ b/tmpl/generator.go
@@ -7,13 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"path"
 
-	gateway "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/descriptor"
 	"github.com/golang/protobuf/proto"
 	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
+	gateway "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/descriptor"
 )
 
 // Generator is the type whose methods generate the output, stored in the associated response structure.
@@ -261,7 +260,7 @@ func (g *Generator) loadTemplate(t *template.Template, tmplPath string) (*templa
 	// Determine the open function.
 	readFile := g.ReadFile
 	if readFile == nil {
-		readFile = ioutil.ReadFile
+		readFile = os.ReadFile
 	}
 
 	// Read the file.

--- a/tmpl/util.go
+++ b/tmpl/util.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"unicode"
 
+	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	gateway "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/descriptor"
 	"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/httprule"
-	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"sourcegraph.com/sourcegraph/prototools/util"
 )
 

--- a/util/util.go
+++ b/util/util.go
@@ -3,7 +3,6 @@ package util // import "sourcegraph.com/sourcegraph/prototools/util"
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"path"
 	"strings"
 
@@ -166,7 +165,7 @@ func PackageName(f *descriptor.FileDescriptorProto) string {
 // plugin, returning any error that occurs.
 func ReadJSONFile(path string) (*plugin.CodeGeneratorRequest, error) {
 	// Read the file.
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)